### PR TITLE
Example manifests and config files - huge refactor of guide

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ file nrm/src/Codegen/Dhall.hs: see header.
 file hsnrm/src/Nrm/Codegen.hs: see header.
 other files and directories:
 
-Copyright (c) 2019, UChicago Argonne, LLC. All Rights Reserved.
+Copyright (c) 2021, UChicago Argonne, LLC. All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,7 +54,7 @@ os.chdir('..')
 # -- Project information -----------------------------------------------------
 
 project = u'NRM'
-copyright = u'2019, Argonne National Laboratory'
+copyright = u'2021, Argonne National Laboratory'
 author = u'Argo team, Argonne National Laboratory'
 
 # The short X.Y version

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,34 +12,10 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+
 import os
-import requests
-outdir = './configfiles'
-base = 'https://raw.githubusercontent.com/anlsys/nrm-core/master/'
-configfiles = ['hsnrm/dhall/types/nrmd.dhall',
-               'hsnrm/dhall/defaults/nrmd.dhall',
-               'resources/defaults/nrmd.json',
-               'examples/nrmd/control.yaml',
-               'hsnrm/dhall/types/manifest.dhall',
-               'hsnrm/dhall/defaults/manifest.dhall',
-               'hsnrm/dhall/defaults/manifest.dhall',
-               'resources/defaults/manifest.json',
-               'examples/manifests/perfwrap.yaml'
-               ]
-
-# Download each of the above for literal-includes in docs
-os.makedirs(outdir, exist_ok=True)
-os.chdir(outdir)
-for file in configfiles:
-    if file not in os.listdir('.'):
-        dirs = file.split('/')
-        with open('_'.join([dirs[-2], dirs[-1]]), 'wb') as f:
-            f.write(requests.get(base+file).content)
-
-os.chdir('..')
-
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import sys
+sys.path.append(os.path.abspath('../examples'))
 
 # import os
 # import sys

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1,47 +1,121 @@
 NRM Configuration/Manifest Guide
 ================================
 
+The ``dhall`` and ``dhall-to-json`` utilities are available as convenience in
+this environment should you need them.
+
+Types common to both daemon configuration and manifest scripts can be found here:
+
+.. literalinclude:: ../examples/common_types.dhall
+   :caption: /examples/common_types.dhall
+   :linenos:
+
 Daemon Configuration
 --------------------
+
+Types
+^^^^^
 
 ``nrmd``'s configuration can be defined
 in ``json``, ``yaml``, or `Dhall`_ formats. Admissible values are defined
 via the following ``dhall`` file:
 
-.. literalinclude:: ./configfiles/types_nrmd.dhall
+.. literalinclude:: ../examples/nrmd/nrmd_types.dhall
+   :caption: /examples/nrmd/nrmd_types.dhall
+   :linenos:
 
-Optional values are filled using defaults that can
-be found in either Dhall or ``json`` format:
+Defaults
+^^^^^^^^
 
-.. literalinclude:: ./configfiles/defaults_nrmd.dhall
+Optional values are filled using defaults, here expressed in
+both ``dhall`` and ``json``:
 
-.. literalinclude:: ./configfiles/defaults_nrmd.json
+.. literalinclude:: ../examples/nrmd/nrmd_defaults.dhall
+   :caption: /examples/nrmd/nrmd_defaults.dhall
+   :linenos:
 
-Attribute merging is always performed with those defaults. Example configurations
-are located in the `examples`_ folder.
+.. literalinclude:: ../examples/nrmd/nrmd_defaults.json
+   :caption: /examples/nrmd/nrmd_defaults.json
+   :linenos:
 
-.. literalinclude:: ./configfiles/nrmd_control.yaml
+Examples
+^^^^^^^^
+
+Attribute merging is always performed with these defaults. Example configurations
+are located in the `examples`_ folder, but we include each of them here. Note that
+Dhall is valid as a configuration language:
+
+.. literalinclude:: ../examples/nrmd/control.yaml
+   :caption: /examples/nrmd/control.yaml
+   :linenos:
+
+.. literalinclude:: ../examples/nrmd/control.dhall
+   :caption: /examples/nrmd/control.dhall
+   :linenos:
+
+.. literalinclude:: ../examples/nrmd/extra-static-sensor.dhall
+   :caption: /examples/nrmd/extra-static-sensor.dhall
+   :linenos:
+
+.. literalinclude:: ../examples/nrmd/extra-static-sensor.yaml
+   :caption: /examples/nrmd/extra-static-sensor.yaml
+   :linenos:
+
+.. literalinclude:: ../examples/nrmd/extra-static-actuator.json
+   :caption: /examples/nrmd/extra-static-actuator.json
+   :linenos:
 
 Manifest Configuration
 ----------------------
 
-Manifest files can also be defined either using Dhall, YAML, or JSON,
-and are in similar formats or locations:
+Types
+^^^^^
 
-.. literalinclude:: ./configfiles/types_manifest.dhall
+Manifest files can also be defined either using Dhall, ``yaml``, or ``json``.
+Admissible values are defined via the following ``dhall`` file:
 
-Under-specified manifests like the one in our ```workloads`` above (with missing
-optional fields from the schema) fill missing values with defaults, which are located
-here:
+.. literalinclude:: ../examples/manifests/manifest_types.dhall
+   :caption: /examples/manifests/manifest_types.dhall
+   :linenos:
 
-.. literalinclude:: ./configfiles/defaults_manifest.dhall
+Defaults
+^^^^^^^^
 
-The ``dhall`` and ``dhall-to-json`` utilities are available as convenience in
-this environment should you need them. Dhall is useful as a configuration language in itself:
+Under-specified manifests are also filled with defaults, specified here
+in both ``dhall`` and ``json``:
 
-.. literalinclude:: ./configfiles/defaults_manifest.json
+.. literalinclude:: ../examples/manifests/manifest_defaults.dhall
+   :caption: /examples/manifests/manifest_defaults.dhall
+   :linenos:
 
-.. literalinclude:: ./configfiles/manifests_perfwrap.yaml
+.. literalinclude:: ../examples/manifests/manifest_defaults.json
+   :caption: /examples/manifests/manifest_defaults.json
+   :linenos:
+
+Examples
+^^^^^^^^
+
+The following could be used with the `libnrm`_ interface:
+
+.. literalinclude:: ../examples/manifests/libnrm.dhall
+   :caption: /examples/manifests/libnrm.dhall
+   :linenos:
+
+.. literalinclude:: ../examples/manifests/libnrm.json
+   :caption: /examples/manifests/libnrm.json
+   :linenos:
+
+The following could be used with the `perf`_ utility:
+
+.. literalinclude:: ../examples/manifests/perfwrap.dhall
+   :caption: /examples/manifests/perfwrap.dhall
+   :linenos:
+
+.. literalinclude:: ../examples/manifests/perfwrap.yaml
+   :caption: /examples/manifests/perfwrap.yaml
+   :linenos:
 
 .. _`Dhall`: https://dhall-lang.org/
-.. _`examples`: https://github.com/anlsys/nrm-core/tree/master/examples
+.. _`examples`: https://github.com/anlsys/nrm-docs/tree/main/examples
+.. _`libnrm`: https://github.com/anlsys/libnrm
+.. _`perf`: https://www.man7.org/linux/man-pages/man1/perf.1.html

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,12 +44,6 @@ and the notebooks under :doc:`NRM-Python<nrm-python:index>` for python upstream 
    NRM-Core <https://nrm.readthedocs.io/projects/nrm-core/en/master/>
 
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Additional References:
-
-   release-notes
-
 Indices and tables
 ==================
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,7 +30,7 @@ and the notebooks under :doc:`NRM-Python<nrm-python:index>` for python upstream 
 
 .. toctree::
    :maxdepth: 2
-   :caption: User Guide:
+   :caption: User Guides:
 
    quickstart
    libnrm

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -17,17 +17,6 @@ Container piece
 The NRM code now supports mapping slices on both Singularity containers and
 NodeOS compute containers.
 
-.. NodeOS
-.. ^^^^^^
-..
-.. For NodeOS container usage, you need to install our container piece
-.. on the system. On a production platform, this should be done by a sysadmin. On
-.. a development platform, this can be achieved with::
-..
-..  git clone https://xgitlab.cels.anl.gov/argo/containers.git
-..  cd containers
-..  make install
-
 Singularity
 ^^^^^^^^^^^
 
@@ -38,30 +27,34 @@ NRM
 ---
 
 The NRM core library must be installed first. Binary releases are available on GitHub_.
-If installation via this route is selected, the ``NRMSO`` and ``PYNRMSO`` environment
-variables must point to the extracted shared library files, e.g.::
+If installing via this method, ensure that ``LD_LIBRARY_PATH`` points to the directory
+that contains the extracted shared library files. Otherwise, set the ``NRMSO``
+and ``PYNRMSO`` environment variables like the following::
 
-    tar xf nrm-core-master.tar.gz
-    export NRMSO=${PWD}/nrm-core-master/lib/libnrm-core.so
-    export PYNRMSO=${PWD}/nrm-core-master/lib/libnrm-core-python.so
+    tar xf nrm-core-v0.7.0-x86_64-linux.tar.gz
+    export NRMSO=${PWD}/nrm-core-v0.7.0-x86_64-linux/lib/libnrm-core.so
+    export PYNRMSO=${PWD}/nrm-core-v0.7.0-x86_64-linux/lib/libnrm-core-python.so
 
-The ``nrm`` client is available in ``nrm-core-master/bin``.
+The ``nrm`` client is available in ``nrm-core-v0.7.0-x86_64-linux/bin``.
 
 Alternatively, the NRM core components (the ``nrmd`` daemon and ``nrm`` client)
 can be installed in other ways:
 
 Using Spack
 ^^^^^^^^^^^
-::
 
- spack install nrm
+The various components of NRM are available on Spack. The ``nrm-core`` package
+contains the core library and ``py-nrm`` contains the Python interface. The ``nrm``
+package contains documentation and example configuration scripts, and also installs
+the other components::
 
-.. Using Nix
-.. ^^^^^^^^^
-..
-.. NRM has a Nix package in our local package repository::
-..
-..  nix-env -f "https://xgitlab.cels.anl.gov/argo/argopkgs/-/archive/master/argopkgs-master.tar.gz" -iA nrm
+
+    spack install nrm-core
+    spack install py-nrm
+
+or::
+
+    spack install nrm
 
 Using Pip
 ^^^^^^^^^
@@ -101,7 +94,7 @@ through its command-line options::
 Running jobs using `nrm`
 ========================
 
-Tasks are configured using a yaml file called a *manifest* and started using the ``nrm``
+Tasks are configured using a config file called a *manifest* and started using the ``nrm``
 command-line utility. Here's an example manifest that allocates two CPUS and
 enables application progress monitoring with a one-second rate limit::
 
@@ -196,4 +189,4 @@ Set a node power target::
 
 
 .. _Singularity: https://singularity.lbl.gov/install-request
-.. _ GitHub: https://github.com/anlsys/nrm-core/releases/tag/master-build
+.. _ GitHub: https://github.com/anlsys/nrm-core/releases

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -189,4 +189,4 @@ Set a node power target::
 
 
 .. _Singularity: https://singularity.lbl.gov/install-request
-.. _ GitHub: https://github.com/anlsys/nrm-core/releases
+.. _GitHub: https://github.com/anlsys/nrm-core/releases

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -17,16 +17,16 @@ Container piece
 The NRM code now supports mapping slices on both Singularity containers and
 NodeOS compute containers.
 
-NodeOS
-^^^^^^
-
-For NodeOS container usage, you need to install our container piece
-on the system. On a production platform, this should be done by a sysadmin. On
-a development platform, this can be achieved with::
-
- git clone https://xgitlab.cels.anl.gov/argo/containers.git
- cd containers
- make install
+.. NodeOS
+.. ^^^^^^
+..
+.. For NodeOS container usage, you need to install our container piece
+.. on the system. On a production platform, this should be done by a sysadmin. On
+.. a development platform, this can be achieved with::
+..
+..  git clone https://xgitlab.cels.anl.gov/argo/containers.git
+..  cd containers
+..  make install
 
 Singularity
 ^^^^^^^^^^^
@@ -37,8 +37,18 @@ page.
 NRM
 ---
 
-The NRM core components (the ``nrmd`` daemon and ``nrm`` client) can be installed
-in multiple ways:
+The NRM core library must be installed first. Binary releases are available on GitHub_.
+If installation via this route is selected, the ``NRMSO`` and ``PYNRMSO`` environment
+variables must point to the extracted shared library files, e.g.::
+
+    tar xf nrm-core-master.tar.gz
+    export NRMSO=${PWD}/nrm-core-master/lib/libnrm-core.so
+    export PYNRMSO=${PWD}/nrm-core-master/lib/libnrm-core-python.so
+
+The ``nrm`` client is available in ``nrm-core-master/bin``.
+
+Alternatively, the NRM core components (the ``nrmd`` daemon and ``nrm`` client)
+can be installed in other ways:
 
 Using Spack
 ^^^^^^^^^^^
@@ -46,21 +56,20 @@ Using Spack
 
  spack install nrm
 
-Using Nix
-^^^^^^^^^
-
-NRM has a Nix package in our local package repository::
-
- nix-env -f "https://xgitlab.cels.anl.gov/argo/argopkgs/-/archive/master/argopkgs-master.tar.gz" -iA nrm
+.. Using Nix
+.. ^^^^^^^^^
+..
+.. NRM has a Nix package in our local package repository::
+..
+..  nix-env -f "https://xgitlab.cels.anl.gov/argo/argopkgs/-/archive/master/argopkgs-master.tar.gz" -iA nrm
 
 Using Pip
 ^^^^^^^^^
 
-You should be able to get NRM and its dependencies on any machine with::
+After obtaining NRM-Core, you should be able to get the NRM Python interface
+and most of its dependencies on any machine with::
 
- pip install git+https://xgitlab.cels.anl.gov/argo/nrm.git
-
-And entering the resulting virtual environment with ``pipenv shell``.
+ pip install https://github.com/anlsys/nrm-python.git
 
 Setup: Launching the `nrmd` daemon
 ==================================
@@ -76,58 +85,25 @@ default.
 -----------------------------
 
 The ``nrmd`` daemon is mainly configured
-through its command-line options.::
+through its command-line options::
 
-  usage: nrmd [-h] [-c FILE] [-d] [-v] [--nrm_log NRM_LOG] [--hwloc HWLOC]
-              [--argo_nodeos_config ARGO_NODEOS_CONFIG] [--perf PERF]
-              [--pmpi_lib PMPI_LIB] [--argo_perf_wrapper ARGO_PERF_WRAPPER]
-              [--singularity SINGULARITY]
-              [--container-runtime {nodeos,singularity}]
+    Usage: nrmd [-i|--stdin] [CONFIG] [-y|--yaml]
+      NRM Daemon
 
-  optional arguments:
-    -h, --help            show this help message and exit
-    -c FILE, --configuration FILE
-                          Specify a config json-formatted config file to
-                          override any of the available CLI options. If an
-                          option is actually provided on the command-line, it
-                          overrides its corresponding value from the
-                          configuration file.
-    -d, --print_defaults  Print the default configuration file.
-    -v, --verbose         increase output verbosity
-    --nrm_log NRM_LOG     Main log file. Override default with the NRM_LOG
-                          environment variable
-    --hwloc HWLOC         Path to the hwloc to use. This path can be relative
-                          and makes uses of the $PATH if necessary. Override
-                          default with the HWLOC environment variable.
-    --argo_nodeos_config ARGO_NODEOS_CONFIG
-                          Path to the argo_nodeos_config to use. This path can
-                          be relative and makes uses of the $PATH if necessary.
-                          Override default with the ARGO_NODEOS_CONFIG
-                          environment variable.
-    --perf PERF           Path to the linux perf tool to use. This path can be
-                          relative and makes uses of the $PATH if necessary.
-                          Override default with the PERF environment variable.
-    --pmpi_lib PMPI_LIB   Path to the libnrm PMPI library used for the power
-                          policy. Override default with the PMPI environment
-                          variable.
-    --argo_perf_wrapper ARGO_PERF_WRAPPER
-                          Path to the linux perf tool to use. This path can be
-                          relative and makes uses of the $PATH if necessary.
-                          Override default with the PERFWRAPPER environment
-                          variable.
-    --singularity SINGULARITY
-                          Path to the singularity command. Override default with
-                          the SINGULARITY environment variable.
-    --container-runtime {nodeos,singularity}
-                          Choice of container runtime. Override default with the
-                          ARGO_CONTAINER_RUNTIME environment variable.
+    Available options:
+      -h,--help                Show this help text
+      -i,--stdin               Read configuration on stdin.
+      CONFIG                   Input configuration with .yml/.yaml/.dh/.dhall
+                               extension. Leave void for stdin (dhall) input.
+      -y,--yaml                Assume configuration to be yaml instead of dhall.
+      -h,--help                Show this help text
 
 Running jobs using `nrm`
 ========================
 
-Tasks are configured using a JSON file called a *manifest* and started using the ``nrm``
+Tasks are configured using a yaml file called a *manifest* and started using the ``nrm``
 command-line utility. Here's an example manifest that allocates two CPUS and
-enables application progress monitoring with a one-second rate limit.::
+enables application progress monitoring with a one-second rate limit::
 
   name: basic
   version: 0.0.1
@@ -220,3 +196,4 @@ Set a node power target::
 
 
 .. _Singularity: https://singularity.lbl.gov/install-request
+.. _ GitHub: https://github.com/anlsys/nrm-core/releases/tag/master-build

--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -1,9 +1,0 @@
-Release Notes
-=============
-
-Release 0.1.0
--------------
-
-:Date: 2019
-
-Initial Release

--- a/examples/common_types.dhall
+++ b/examples/common_types.dhall
@@ -1,0 +1,13 @@
+let Power =
+    -- Base unit: power.
+      { microwatts : Double }
+
+let Time =
+    -- Base unit: time.
+      { microseconds : Double }
+
+let Frequency =
+    --Base unit: frequency.
+      { hertz : Double }
+
+in  { Frequency = Frequency, Time = Time, Power = Power }

--- a/examples/manifests/libnrm.dhall
+++ b/examples/manifests/libnrm.dhall
@@ -1,0 +1,11 @@
+let types = ./types_manifest.dhall
+
+let default = ./defaults_manifest.dhall
+
+in      default
+      ⫽ { name = "libnrm-wrapped"
+        , app =
+              default.app
+            ⫽ { instrumentation = Some { ratelimit.hertz = 1000000.0 } }
+        }
+    : types.Manifest

--- a/examples/manifests/libnrm.json
+++ b/examples/manifests/libnrm.json
@@ -1,0 +1,10 @@
+{
+  "name": "libnrm-wrapped",
+  "app": {
+    "instrumentation": {
+      "ratelimit": {
+        "hertz": 1000000
+      }
+    }
+  }
+}

--- a/examples/manifests/manifest_defaults.dhall
+++ b/examples/manifests/manifest_defaults.dhall
@@ -1,0 +1,16 @@
+-- ******************************************************************************
+--  Copyright 2021 UChicago Argonne, LLC.
+--  (c.f. AUTHORS, LICENSE)
+--
+--  SPDX-License-Identifier: BSD-3-Clause
+-- ******************************************************************************
+
+let t = ./types_manifest.dhall
+
+in  { name = "default"
+    , app =
+        { perfwrapper = None t.Perfwrapper
+        , instrumentation = None t.Instrumentation
+        , actuators = None (List t.AppActuatorKV)
+        }
+    }

--- a/examples/manifests/manifest_defaults.json
+++ b/examples/manifests/manifest_defaults.json
@@ -1,0 +1,7 @@
+{
+    "app": {
+        "instrumentation": null,
+        "perfwrapper": null
+    },
+    "name": "default"
+}

--- a/examples/manifests/manifest_types.dhall
+++ b/examples/manifests/manifest_types.dhall
@@ -1,0 +1,66 @@
+-- ******************************************************************************
+--  Copyright 2021 UChicago Argonne, LLC.
+--  (c.f. AUTHORS, LICENSE)
+--
+--  SPDX-License-Identifier: BSD-3-Clause
+-- ******************************************************************************
+let types =
+    -- This import defines a few base types that are common to manifest and
+    -- configuration formats.
+      ../common_types.dhall
+
+let Perfwrapper =
+    -- Configuration for linux perf performance measurements. A fixed frequency
+    -- is provided, along with a tentative upper bound on the maximum value of
+    -- the sensor. This upper bound should be set to a low positive value if
+    -- no a-priori information is known; NRM will then use a recursive-doubling
+    -- strategy to maintain its own bound.
+      { perfFreq : types.Frequency
+      , perfLimit : Integer
+      , perfEvent : Text
+      }
+
+let Instrumentation =
+    -- Activate LD_PRELOAD based `libnrm` instrumentation. The only attribute that configures this feature
+    -- is a message rate limitation.
+      { ratelimit : types.Frequency }
+
+let EnvVar =
+    -- Key-value representation of environment variables
+      { envName : Text, envValue : Text }
+
+let AppActuator =
+    -- Configuration for an arbitrary actuator.
+      { actuatorBinary : Text
+      , actuatorArguments : List Text
+      , actuatorEnv : List EnvVar
+      , actions : List Double
+      , referenceAction : Double
+      }
+
+let AppActuatorKV =
+    -- Key-value representation for an actuator.
+      { actuatorID : Text, actuator : AppActuator }
+
+let App =
+    -- Application configuration. Two features can be enabled or disabled:
+    -- perfwrapper: an optional linux perf configuration
+    -- instrumentation: an optional libnrm instrumentation configuration
+      { perfwrapper : Optional Perfwrapper
+      , instrumentation : Optional Instrumentation
+      , actuators : Optional (List AppActuatorKV)
+      }
+
+let Manifest =
+    -- A manifest has a name, and an application configuration.
+      { name : Text, app : App }
+
+in    types
+    ⫽ { Perfwrapper = Perfwrapper
+      , Instrumentation = Instrumentation
+      , App = App
+      , Manifest = Manifest
+      , AppActuator = AppActuator
+      , AppActuatorKV = AppActuatorKV
+      , EnvVar = EnvVar
+      }

--- a/examples/manifests/perfwrap.dhall
+++ b/examples/manifests/perfwrap.dhall
@@ -1,0 +1,14 @@
+let types = ./types_manifest.dhall
+
+let default = ./defaults_manifest.dhall
+
+in      default
+      ⫽ { name = "linuxperf-wrapped"
+        , app =
+              default.app
+            ⫽ { perfwrapper = Some { perfFreq.hertz = 1.0,
+	    			     perfLimit = +100000,
+				     perfEvent = "instructions" }
+              }
+        }
+    : types.Manifest

--- a/examples/manifests/perfwrap.yaml
+++ b/examples/manifests/perfwrap.yaml
@@ -1,0 +1,7 @@
+name: linuxperf-wrapped
+app:
+  perfwrapper:
+    perfFreq:
+      hertz: 1
+    perfLimit: 100000
+    perfEvent: "instructions"

--- a/examples/nrmd/control.dhall
+++ b/examples/nrmd/control.dhall
@@ -1,0 +1,27 @@
+let types = ./types_nrmd.dhall
+
+let default = ./defaults_nrmd.dhall
+
+let action1 = { microwatts = 1.0e8 }
+
+let action2 = { microwatts = 2.0e8 }
+
+in      default
+      ⫽ { raplCfg = Some
+            { raplPath = "/sys/devices/virtual/powercap/intel-rapl"
+            , raplActions = [ action1, action2 ]
+            , referencePower.microwatts = 2.5e8
+            }
+        , controlCfg =
+            types.ControlCfg.ControlCfg
+              { minimumControlInterval.microseconds = 100000.0
+              , minimumWaitInterval.microseconds = 100000.0
+              , staticPower.microwatts = 2.0e8
+              , learnCfg = types.LearnCfg.Contextual { horizon = +4000 }
+              , speedThreshold = 1.1
+              , referenceMeasurementRoundInterval = +6
+              , hint = types.Hint.Full
+              }
+        , passiveSensorFrequency.hertz = 1.0
+        }
+    : types.Cfg

--- a/examples/nrmd/control.yaml
+++ b/examples/nrmd/control.yaml
@@ -1,0 +1,21 @@
+passiveSensorFrequency:
+  hertz: 1
+controlCfg:
+  hint: Full
+  learnCfg:
+    horizon: 4000
+  minimumWaitInterval:
+    microseconds: 100000
+  minimumControlInterval:
+    microseconds: 100000
+  referenceMeasurementRoundInterval: 6
+  speedThreshold: 1.1
+  staticPower:
+    microwatts: 200000000
+raplCfg:
+  raplActions:
+    - microwatts: 100000000
+    - microwatts: 200000000
+  raplPath: /sys/devices/virtual/powercap/intel-rapl
+  referencePower:
+    microwatts: 250000000

--- a/examples/nrmd/extra-static-actuator.json
+++ b/examples/nrmd/extra-static-actuator.json
@@ -1,0 +1,20 @@
+{
+  "extraStaticActuators": [
+    {
+      "actuatorID": "example extra actuator ID",
+      "actuator": {
+        "actions": [
+          1,
+          2
+        ],
+        "actuatorArguments": [
+          "-c",
+          "echo $@ >> /tmp/test-nrm-example-extra-actuator",
+          "-o"
+        ],
+        "actuatorBinary": "bash",
+        "referenceAction": 1
+      }
+    }
+  ]
+}

--- a/examples/nrmd/extra-static-sensor.dhall
+++ b/examples/nrmd/extra-static-sensor.dhall
@@ -1,0 +1,18 @@
+let types = ./types_nrmd.dhall
+
+let default = ./defaults_nrmd.dhall
+
+in      default
+      ⫽ { extraStaticPassiveSensors =
+          [ { sensorID = "example extra static passive power sensor"
+            , sensor =
+                { sensorBinary = "echo"
+                , sensorArguments = [ "30" ]
+                , range = { lower = 1.0, upper = 40.0 }
+                , tags = [ types.Tag.TagPower ]
+                , sensorBehavior = types.SensorBehavior.IntervalBased
+                }
+            }
+          ]
+        }
+    : types.Cfg

--- a/examples/nrmd/extra-static-sensor.yaml
+++ b/examples/nrmd/extra-static-sensor.yaml
@@ -1,0 +1,12 @@
+extraStaticPassiveSensors:
+  - sensorID: "example extra static passive power sensor"
+    sensor:
+      range:
+        lower: 1
+        upper: 40
+      sensorArguments:
+        - "30"
+      sensorBehavior: IntervalBased
+      sensorBinary: echo
+      tags:
+        - TagPower

--- a/examples/nrmd/nrmd_defaults.dhall
+++ b/examples/nrmd/nrmd_defaults.dhall
@@ -1,0 +1,21 @@
+let t = ./types_nrmd.dhall
+
+in    { verbose = t.Verbosity.Error
+      , logfile = "/tmp/nrm.log"
+      , perfPath = "perf"
+      , perfwrapperPath = "nrm-perfwrapper"
+      , libnrmPath = None Text
+      , downstreamCfg.downstreamBindAddress = "ipc:///tmp/nrm-downstream-event"
+      , upstreamCfg =
+          { upstreamBindAddress = "*", pubPort = +2345, rpcPort = +3456 }
+      , raplCfg = Some
+          { raplPath = "/sys/devices/virtual/powercap/intel-rapl"
+          , raplActions = [ { microwatts = 1.0e8 }, { microwatts = 2.0e8 } ]
+          , referencePower.microwatts = 2.5e8
+          }
+      , controlCfg = t.ControlCfg.ControlOff
+      , passiveSensorFrequency.hertz = 1.0
+      , extraStaticPassiveSensors = [] : List t.SensorKV
+      , extraStaticActuators = [] : List t.ActuatorKV
+      }
+    : t.Cfg

--- a/examples/nrmd/nrmd_defaults.json
+++ b/examples/nrmd/nrmd_defaults.json
@@ -1,0 +1,35 @@
+{
+    "extraStaticPassiveSensors": [],
+    "perfPath": "perf",
+    "verbose": "Error",
+    "logfile": "/tmp/nrm.log",
+    "controlCfg": "ControlOff",
+    "upstreamCfg": {
+        "upstreamBindAddress": "*",
+        "rpcPort": 3456,
+        "pubPort": 2345
+    },
+    "libnrmPath": null,
+    "downstreamCfg": {
+        "downstreamBindAddress": "ipc:///tmp/nrm-downstream-event"
+    },
+    "perfwrapperPath": "nrm-perfwrapper",
+    "extraStaticActuators": [],
+    "raplCfg": {
+        "referencePower": {
+            "microwatts": 250000000
+        },
+        "raplActions": [
+            {
+                "microwatts": 100000000
+            },
+            {
+                "microwatts": 200000000
+            }
+        ],
+        "raplPath": "/sys/devices/virtual/powercap/intel-rapl"
+    },
+    "passiveSensorFrequency": {
+        "hertz": 1
+    }
+}

--- a/examples/nrmd/nrmd_types.dhall
+++ b/examples/nrmd/nrmd_types.dhall
@@ -1,0 +1,175 @@
+-- ******************************************************************************
+--  Copyright 2021 UChicago Argonne, LLC.
+--  (c.f. AUTHORS, LICENSE)
+--
+--  SPDX-License-Identifier: BSD-3-Clause
+-- ******************************************************************************
+--
+-- types used by nrmd's configuration.
+--
+--
+let types =
+    -- This import defines a few base types that are common to manifest and
+    -- configuration formats.
+      ../common_types.dhall
+
+let Verbosity =
+    -- Daemon verbosity:
+    --   Error: Only report errors
+    --   Info: Be verbose
+    --   Debug: Report all that can possibly be reported
+      < Error | Info | Debug >
+
+let SensorBehavior =
+    -- Sensor Behavior.
+    -- IntervalBased: a sensor that measures an average value for the time
+    -- period since its last reading.
+    -- Cumulative: a sensor that measures a counter. NRM must substract between
+    -- subsequent counter values to obtain a reading for the corresponding time
+    -- period.
+    -- CumulativeWithCapacity: same as `Cumulative`, except the sensor gives
+    -- bounded values that go back to zero after a given threshold. Typical of
+    -- RAPL sysfs sensors, for instance .
+      < IntervalBased | Cumulative | CumulativeWithCapacity : Double >
+
+let Range =
+    -- An inclusive range of values
+      { lower : Double, upper : Double }
+
+let DownstreamCfg =
+    -- Configuration for the dowstream API
+      { downstreamBindAddress : Text }
+
+let UpstreamCfg =
+    -- Configuration for the upstream API
+      { upstreamBindAddress : Text, pubPort : Integer, rpcPort : Integer }
+
+let Tag =
+    -- Available tags for describing sensors. Tags are used for setting
+    -- objective functions up.
+      < TagPower
+      | TagRapl
+      | TagDownstreamThreadSignal
+      | TagDownstreamCmdSignal
+      | TagMinimize
+      | TagMaximize
+      >
+
+let Sensor =
+    -- Configuration for an arbitrary sensor.
+      { sensorBinary : Text
+      , sensorArguments : List Text
+      , range : Range
+      , tags : List Tag
+      , sensorBehavior : SensorBehavior
+      }
+
+let Actuator =
+    -- Configuration for an arbitrary actuator.
+      { actuatorBinary : Text
+      , actuatorArguments : List Text
+      , actions : List Double
+      , referenceAction : Double
+      }
+
+let ActuatorKV =
+    -- Key-value representation for an actuator.
+      { actuatorID : Text, actuator : Actuator }
+
+let SensorKV =
+    -- Key-value representation for a sensor.
+      { sensorID : Text, sensor : Sensor }
+
+let RaplCfg =
+    -- Configuration for auto-discovered RAPL power sensors/actuators
+      { raplPath : Text
+      , raplActions : List types.Power
+      , referencePower : types.Power
+      }
+
+let ActuatorValue =
+    -- Actuator value configuration for the internal control loop configuration.
+      { actuatorValueID : Text, actuatorValue : Double }
+
+let Hint =
+    -- Action space configuration for internal control loop.
+      < Full
+      | Only :
+          { neHead : List ActuatorValue, neTail : List (List ActuatorValue) }
+      >
+
+let LearnCfg =
+    -- Internal control loop algorithm type and hyperparameters.
+      < Lagrange : { lagrange : Double }
+      | Random : { seed : Integer }
+      | Contextual : { horizon : Integer }
+      >
+
+let ControlCfg =
+    -- Root control configuration.
+    -- ControlCfg: configures an internal control loop
+    -- ControlOff: bypass mode
+      < ControlCfg :
+          { minimumControlInterval : types.Time
+          , minimumWaitInterval : types.Time
+          , staticPower : types.Power
+          , learnCfg : LearnCfg
+          , speedThreshold : Double
+          , referenceMeasurementRoundInterval : Integer
+          , hint : Hint
+          }
+      | ControlOff
+      >
+
+let Cfg =
+    -- The configuration type for `nrmd`.
+    -- verbose : a verbosity level configuration.
+    -- logfile : the main log file for the daemon.
+    -- perfPath : the path/binary name of the linux perf executable.
+    -- perfwrapperPath : the path/binary name of the nrm-perfwrapper executable
+    -- libnrmPath : the path to the libnrm.so to use. leave at None to disable
+    --              the feature globally (for all apps).
+    -- downstreamCfg : Downstream API configuration.
+    -- upstreamCfg : Upstream API configuration.
+    -- raplCfg : RAPL configuration. Leave at None to disable the feature
+    --           globally.
+    -- controlCfg : resource control configuration
+    -- passiveSensorFrequency : unified frequency for all NRM's passive sensors.
+    -- extraStaticPassiveSensors : list of extra static passive sensors.
+    -- extraStaticActuators : list of extra actuators.
+      { verbose : Verbosity
+      , logfile : Text
+      , perfPath : Text
+      , perfwrapperPath : Text
+      , libnrmPath : Optional Text
+      , downstreamCfg : DownstreamCfg
+      , upstreamCfg : UpstreamCfg
+      , raplCfg : Optional RaplCfg
+      , controlCfg : ControlCfg
+      , passiveSensorFrequency : types.Frequency
+      , extraStaticPassiveSensors : List SensorKV
+      , extraStaticActuators : List ActuatorKV
+      }
+
+let output =
+      { Verbosity = Verbosity
+      , UpstreamCfg = UpstreamCfg
+      , DownstreamCfg = DownstreamCfg
+      , Tag = Tag
+      , SensorBehavior = SensorBehavior
+      , Actuator = Actuator
+      , SensorKV = SensorKV
+      , Sensor = Sensor
+      , ActuatorKV = ActuatorKV
+      , Range = Range
+      , PassiveSensorCfg = Sensor
+      , ActuatorValue = ActuatorValue
+      , ActuatorCfg = Actuator
+      , LearnCfg = LearnCfg
+      , RaplCfg = RaplCfg
+      , ControlCfg = ControlCfg
+      , Hint = Hint
+      , Cfg = Cfg
+      }
+
+in  types ⫽ output


### PR DESCRIPTION
Initial attempt at migrating some example configuration and manifest files from nrm-core to nrm-docs, then including them in the documentation. These examples would be distributed with a release of nrm-docs.

Relevant page is here: https://nrm--5.org.readthedocs.build/projects/nrm-docs/en/5/config.html